### PR TITLE
fix a typo in pickrandom()

### DIFF
--- a/shadow_useragent/core.py
+++ b/shadow_useragent/core.py
@@ -85,7 +85,7 @@ class ShadowUserAgent(object):
         limited_uas = [ua for ua in uas if ua["browser_family"] != "Other"]
         if exclude_mobile:
             limited_uas = [ua for ua in uas if ua["browser_family"] != "Android" and ua["browser_family"] != "Mobile Safari"]
-        return random.choice(uas)["useragent"]
+        return random.choice(limited_uas)["useragent"]
 
     def random_details(self):
         self.update()


### PR DESCRIPTION
I used to the shadow-useragent in my scraping project, and some xpaths failed. 

I investigated the reason and found that the no_mobile property also returns mobile uas despite of the name. 

So I look into the source code and found this little typo.