### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "pip install shadow-useragent"

--- a/README.md
+++ b/README.md
@@ -107,3 +107,4 @@ from shadow_useragent import ShadowUserAgent
 shadow_useragent = ShadowUserAgent()
 shadow_useragent.force_update()
 ```
+[![Run on Repl.it](https://repl.it/badge/github/lobstrio/shadow-useragent)](https://repl.it/github/lobstrio/shadow-useragent)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@rpanchanathan/shadow-useragent).